### PR TITLE
2nd book's source changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ Descriptions and implementations of Ethereum-related protocols.
 ## Books
 
 - [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) - A developers guide to the operation and use of Ethereum.
-- [Introduction to Ethereum and Solidity](https://the-eye.eu/public/Books/qt.vidyagam.es/library/humble-bitcoin-bundle/Introducing%20Ethereum%20and%20Solidity_%20Foud%20Blockchain%20Programming%20for%20Beginners/Introducing%20Ethereum%20and%20Solidity_%20Foundatiin%20Programming%20for%20Beginners%20-%20Chris%20Dannen.pdf) - Learn Solidity development from concept to deployment.
+- [Introduction to Ethereum and Solidity](http://ndl.ethernet.edu.et/bitstream/123456789/26027/1/Chris%20Dannen.pdf) - Learn Solidity development from concept to deployment.
 - [Ethereum: Blockchains, Digital Assets, Smart Contracts, Decentralized Autonomous Organizations](https://www.goodreads.com/book/show/32762240-ethereum) - Learn about Ethereum (and blockchains) from an IBM blockchain liason.
 
 


### PR DESCRIPTION
The old source for the Introducing Ethereum and Solidity book was not working. New link is working.