### PR TITLE
Add DeFiMath to Programming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ Official Ethereum Documentation.
 - [Embark Framework](https://github.com/embark-framework/embark) - Framework for serverless Decentralized Applications using Ethereum, IPFS and other platforms.
 - [Eth Fiddle](https://ethfiddle.com/) - Online editor for smart contracts.
 - [Hardhat](https://hardhat.org/) - Ethereum development environment for professionals.
+- [DeFiMath](https://defimath.com) - Gas-optimized Solidity library for DeFi math: Black-Scholes option pricing, Greeks, interest rates, and statistics.
 
 
 ## Tutorials


### PR DESCRIPTION
Adds [DeFiMath](https://defimath.com) to the Programming section.

DeFiMath is a pure-Solidity, MIT-licensed library of DeFi math primitives — Black-Scholes option pricing (~2,876 gas, ~4.6× cheaper than next-best on-chain implementation), Greeks, IV solver, interest-rate math, and statistics. No runtime dependencies.